### PR TITLE
fix SQLite3Cursor boolean converter

### DIFF
--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
@@ -92,7 +92,6 @@ internal class SQLite3Cursor(val statementInit: suspend () -> Sqlite3.Statement)
     }
 
     override fun getBoolean(index: Int): Boolean? {
-        checkCursorState()
-        return row?.get(index) as Boolean?
+        return getLong(index)?.let { it != 0L }
     }
 }


### PR DESCRIPTION
SQLite uses integers to represent booleans. Directly converting row value to booleans will always fail.