### PR TITLE
CI: OSSRH sunset, publishing for Maven Central changed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,8 +177,8 @@ publishing {
         maven { // OSS Sonatype (default)
             val isSnapshot = version.toString().endsWith("SNAPSHOT")
             val destination = if (!isSnapshot) {
-                "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            } else "https://s01.oss.sonatype.org/content/repositories/snapshots"
+                "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            } else "https://central.sonatype.com/repository/maven-snapshots/"
             url = uri(destination)
             credentials {
                 username = System.getenv("SONATYPE_USER") ?: localProperties["sonatype.user"] as String?


### PR DESCRIPTION
Article: https://central.sonatype.org/pages/ossrh-eol/#process-to-migrate

changes based on documentation here:
https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-nexus-repository-manager-2-api-plugins