### PR TITLE
Fix transaction, statement lifecycle and cursor bugs in the driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,18 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.head_ref }}
 
-      - name: Setup detekt
-        uses: peter-murray/setup-detekt@v2
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          detekt_version: 1.22.0
+          java-version: '17'
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
       - name: Run detekt
-        run: detekt-cli -c gradle/detekt/detekt.yml
+        run: ./gradlew detekt
 
   build:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
+import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.yarn.yarn
@@ -205,8 +206,12 @@ detekt {
     buildUponDefaultConfig = true // preconfigure defaults
     allRules = false // activate all available (even unstable) rules.
     config.setFrom("$projectDir/gradle/detekt/detekt.yml") // point to your custom config defining rules to run, overwriting default behavior
+    // default source dirs are JVM-only, KMP source sets have to be added explicitly, generated code is skipped
+    source.setFrom(kotlin.sourceSets.flatMap { it.kotlin.srcDirs }.filter { it.startsWith(file("src")) })
 //   baseline = file("$projectDir/config/baseline.xml") // a way of suppressing issues before introducing detekt
+}
 
+tasks.withType<Detekt>().configureEach {
     reports {
         html.required.set(true) // observe findings in your browser with structure and code snippets
     }

--- a/gradle/detekt/detekt.yml
+++ b/gradle/detekt/detekt.yml
@@ -534,12 +534,14 @@ style:
     includeLineWrapping: false
   ForbiddenComment:
     active: true
-    values:
-      - 'FIXME:'
-      - 'STOPSHIP:'
-      - 'TODO:'
+    comments:
+      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+        value: 'FIXME:'
+      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+        value: 'STOPSHIP:'
+      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+        value: 'TODO:'
     allowedPatterns: ''
-    customMessage: ''
   ForbiddenImport:
     active: false
     imports: [ ]
@@ -616,8 +618,6 @@ style:
   OptionalAbstractKeyword:
     active: true
   OptionalUnit:
-    active: false
-  OptionalWhenBraces:
     active: false
   PreferToOverPairSyntax:
     active: false

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
@@ -2,90 +2,61 @@ package cz.sazel.sqldelight.node.sqlite3
 
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
+import kotlinx.coroutines.suspendCancellableCoroutine
 import node.sqlite3.Sqlite3
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+
+@JsName("Object")
+private external object JsObject {
+    fun values(obj: Any): Array<dynamic>
+}
 
 internal class SQLite3Cursor internal constructor(val statementInit: suspend () -> Sqlite3.Statement) : SqlCursor {
 
-    private val jsObject = js("Object") //TODO this is weird, find way to improve
-    private lateinit var statement: Sqlite3.Statement
+    private var statement: Sqlite3.Statement? = null
     private var row: Array<dynamic>? = null
 
-    private var initialized = false;
-    private var counter = 0
-
     override fun next(): QueryResult<Boolean> = QueryResult.AsyncValue {
-        if (!initialized) { // initialization
-            statement = statementInit()
-            reset()
-            initialized = true
+        val statement = statement ?: statementInit().also {
+            statement = it
+            it.resetSuspending()
         }
-        row = fetchRow()
-        if (row == null) {
-            return@AsyncValue false
-        }
-        counter++
-        true
+        row = statement.fetchRow()
+        row != null
     }
 
-    private suspend fun fetchRow(): Array<dynamic>? {
-        val result: Array<dynamic>? = suspendCoroutine { cont ->
-            val callback: (row: Any?, row2: Any?) -> Unit = { row, row2 ->
-                if (row == null && row2 != null) {
-                    cont.resume(jsObject.values(row2))
-                } else if (row != null) {
-                    cont.resumeWithException(SQLite3JsException(row as Throwable?))
-                } else {
-                    cont.resume(null)
+    private suspend fun Sqlite3.Statement.fetchRow(): Array<dynamic>? =
+        suspendCancellableCoroutine { cont ->
+            get { err, row ->
+                when {
+                    err != null -> cont.resumeWithException(SQLite3JsException(err))
+                    row != null -> cont.resume(JsObject.values(row))
+                    else -> cont.resume(null)
                 }
             }
-            statement = statement.get(callback)
         }
-        return result
-    }
 
-    private suspend fun reset() {
-        suspendCoroutine { cont ->
-            val callback: (Nothing?) -> Unit = {
-                cont.resume(Unit)
-            }
-            statement.reset(callback)
+    private suspend fun Sqlite3.Statement.resetSuspending(): Unit =
+        suspendCancellableCoroutine { cont ->
+            reset { cont.resume(Unit) }
         }
-    }
 
-    private fun checkCursorState() {
-        if (row == null) throw SQLite3Exception(
-            "Cursor was either not yet iterated or " +
-                    "already iterated all over, call next() first."
-        )
-    }
+    private fun requireRow(): Array<dynamic> = row ?: throw SQLite3Exception(
+        "Cursor was either not yet iterated or " +
+                "already iterated all over, call next() first."
+    )
 
-    override fun getString(index: Int): String? {
-        checkCursorState()
-        return row?.get(index) as String?
-    }
+    override fun getString(index: Int): String? = requireRow()[index] as String?
 
-    override fun getLong(index: Int): Long? {
-        checkCursorState()
-        val value = row?.get(index) as? Number
-        return value?.toLong()
-    }
+    override fun getLong(index: Int): Long? = (requireRow()[index] as? Number)?.toLong()
 
-    override fun getBytes(index: Int): ByteArray? {
-        checkCursorState()
-        return (row?.get(index) as? Uint8Array)?.let { Int8Array(it.buffer).unsafeCast<ByteArray>() }
-    }
+    override fun getBytes(index: Int): ByteArray? =
+        (requireRow()[index] as? Uint8Array)?.let { Int8Array(it.buffer).unsafeCast<ByteArray>() }
 
-    override fun getDouble(index: Int): Double? {
-        checkCursorState()
-        return row?.get(index) as Double?
-    }
+    override fun getDouble(index: Int): Double? = (requireRow()[index] as? Number)?.toDouble()
 
-    override fun getBoolean(index: Int): Boolean? {
-        return getLong(index)?.let { it != 0L }
-    }
+    override fun getBoolean(index: Int): Boolean? = getLong(index)?.let { it != 0L }
 }

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Cursor.kt
@@ -11,6 +11,7 @@ import kotlin.coroutines.resumeWithException
 
 @JsName("Object")
 private external object JsObject {
+    @Suppress("UnusedParameter")
     fun values(obj: Any): Array<dynamic>
 }
 

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
@@ -3,12 +3,12 @@ package cz.sazel.sqldelight.node.sqlite3
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
 import app.cash.sqldelight.db.*
+import kotlinx.coroutines.suspendCancellableCoroutine
 import node.sqlite3.Sqlite3
 import node.sqlite3.Sqlite3.OPEN_CREATE
 import node.sqlite3.Sqlite3.OPEN_READWRITE
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 suspend fun initSqlite3SqlDriver(
     filename: String, mode: Number? = null,
@@ -25,43 +25,35 @@ private fun initSqlite3Database(
 internal suspend fun SQLite3Driver.withSchema(schema: SqlSchema<QueryResult.AsyncValue<Unit>>? = null) =
     this.also { schema?.create(it)?.await() }
 
-internal suspend fun (Sqlite3.Statement).finalizeSuspending() {
-    suspendCoroutine<Any?> { cont ->
-        val callback: (err: Error?) -> Unit = {
-            if (it == null) {
-                cont.resume(it)
-            } else {
-                cont.resumeWithException(SQLite3JsException(it))
-            }
+internal suspend fun (Sqlite3.Statement).finalizeSuspending(): Unit =
+    suspendCancellableCoroutine { cont ->
+        finalize { err ->
+            if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
         }
-        finalize(callback)
     }
-}
+
+private suspend fun (Sqlite3.Database).execSuspending(sql: String): Unit =
+    suspendCancellableCoroutine { cont ->
+        exec(sql) { err ->
+            if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
+        }
+    }
 
 class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : SqlDriver {
     private val listeners = mutableMapOf<String, MutableSet<Query.Listener>>()
     private var transaction: Transaction? = null
 
     internal inner class Transaction(
-        override val enclosingTransaction: Transacter.Transaction?,
+        override val enclosingTransaction: Transaction?,
     ) : Transacter.Transaction() {
         internal val statements = mutableMapOf<Int, Sqlite3.Statement>()
         override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.AsyncValue {
             if (enclosingTransaction == null) {
-                statements.onEach { it.value.finalizeSuspending() }
-                val sql = if (successful) "END TRANSACTION" else "ROLLBACK TRANSACTION"
-                suspendCoroutine { cont ->
-                    val callback: (Any?) -> Unit = {
-                        if (it == null || it !is Throwable) {
-                            cont.resume(it)
-                        } else {
-                            cont.resumeWithException(SQLite3JsException(it))
-                        }
-                    }
-                    db.exec(sql, callback)
-                }
+                statements.values.forEach { it.finalizeSuspending() }
+                statements.clear()
+                db.execSuspending(if (successful) "END TRANSACTION" else "ROLLBACK TRANSACTION")
             }
-            transaction = this
+            transaction = enclosingTransaction
         }
 
         /**
@@ -71,27 +63,17 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
     }
 
     private suspend fun createOrGetStatement(identifier: Int?, sql: String): Sqlite3.Statement {
+        identifier?.let { transaction?.statements?.get(it) }?.let { return it }
 
-        val preparedStatement = suspendCoroutine { cont ->
+        val preparedStatement: Sqlite3.Statement = suspendCancellableCoroutine { cont ->
             lateinit var statement: Sqlite3.Statement
-            val callback: (Any) -> Unit = {
-                if (it is Throwable) {
-                    cont.resumeWithException(SQLite3JsException(it))
-                } else {
-                    cont.resume(statement)
-                }
+            statement = db.prepare(sql) { err ->
+                if (err != null) cont.resumeWithException(SQLite3JsException(err)) else cont.resume(statement)
             }
-            statement = db.prepare(sql, callback)
         }
 
-        val res = if (identifier == null) {
-            preparedStatement
-        } else {
-            transaction?.statements?.getOrPut(identifier) {
-                return@getOrPut preparedStatement
-            } ?: preparedStatement
-        }
-        return res
+        if (identifier != null) transaction?.statements?.put(identifier, preparedStatement)
+        return preparedStatement
     }
 
     override fun execute(
@@ -100,20 +82,17 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
     ): QueryResult<Long> = QueryResult.AsyncValue {
         val statement = createOrGetStatement(identifier, sql)
         statement.bind(parameters, binders)
-        suspendCoroutine { cont ->
-            val callback: (Any) -> Unit = {
-                if (it is Throwable) {
-                    cont.resumeWithException(SQLite3JsException(it))
-                } else {
-                    cont.resume(Unit)
-                }
+        suspendCancellableCoroutine { cont ->
+            statement.run { err ->
+                if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
             }
-            statement.run(callback)
         }
+        // node-sqlite3 sets `changes` on the statement itself right before firing the run callback
+        val changes = statement.unsafeCast<Sqlite3.RunResult>().changes.toLong()
         if (transaction == null) {
             statement.finalizeSuspending()
         }
-        return@AsyncValue 0
+        return@AsyncValue changes
     }
 
     override fun <R> executeQuery(
@@ -136,16 +115,7 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
         val transaction = Transaction(enclosing)
         this.transaction = transaction
         if (enclosing == null) {
-            suspendCoroutine { cont ->
-                val callback: (Any?) -> Unit = {
-                    if (it == null || it !is Throwable) {
-                        cont.resume(it)
-                    } else {
-                        cont.resumeWithException(SQLite3JsException(it))
-                    }
-                }
-                db.exec("BEGIN TRANSACTION", callback)
-            }
+            db.execSuspending("BEGIN TRANSACTION")
         }
 
         return@AsyncValue transaction
@@ -174,27 +144,21 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
     }
 
     override fun close() {
-        db.close {
-            println(it)
+        db.close { err ->
+            if (err != null) println(err)
         }
     }
 
     private suspend fun Sqlite3.Statement.bind(
         parameters: Int,
         binders: (SqlPreparedStatement.() -> Unit)?
-    ) = binders?.let {
-        if (parameters > 0) {
-            val bound = SQLite3PreparedStatement(parameters)
-            binders(bound)
-            suspendCoroutine { cont ->
-                val callback: (Any?) -> Unit = {
-                    if (it == null || it !is Throwable) {
-                        cont.resume(it)
-                    } else {
-                        cont.resumeWithException(SQLite3JsException(it))
-                    }
-                }
-                bind(bound.parameters.toTypedArray(), callback = callback)
+    ) {
+        if (binders == null || parameters <= 0) return
+        val bound = SQLite3PreparedStatement(parameters)
+        binders(bound)
+        suspendCancellableCoroutine { cont ->
+            bind(bound.parameters.toTypedArray()) { err ->
+                if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
             }
         }
     }

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
@@ -76,23 +76,28 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
         return preparedStatement
     }
 
+    /** Statements cached by a transaction are reused and finalized by [Transaction.endTransaction], not by the caller. */
+    private suspend fun Sqlite3.Statement.finalizeUnlessCached() {
+        if (transaction?.statements?.containsValue(this) != true) finalizeSuspending()
+    }
+
     override fun execute(
         identifier: Int?, sql: String,
         parameters: Int, binders: (SqlPreparedStatement.() -> Unit)?
     ): QueryResult<Long> = QueryResult.AsyncValue {
         val statement = createOrGetStatement(identifier, sql)
-        statement.bind(parameters, binders)
-        suspendCancellableCoroutine { cont ->
-            statement.run { err ->
-                if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
+        try {
+            statement.bind(parameters, binders)
+            suspendCancellableCoroutine { cont ->
+                statement.run { err ->
+                    if (err == null) cont.resume(Unit) else cont.resumeWithException(SQLite3JsException(err))
+                }
             }
+            // node-sqlite3 sets `changes` on the statement itself right before firing the run callback
+            statement.unsafeCast<Sqlite3.RunResult>().changes.toLong()
+        } finally {
+            statement.finalizeUnlessCached()
         }
-        // node-sqlite3 sets `changes` on the statement itself right before firing the run callback
-        val changes = statement.unsafeCast<Sqlite3.RunResult>().changes.toLong()
-        if (transaction == null) {
-            statement.finalizeSuspending()
-        }
-        return@AsyncValue changes
     }
 
     override fun <R> executeQuery(
@@ -101,13 +106,19 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
         mapper: (SqlCursor) -> QueryResult<R>,
         parameters: Int,
         binders: (SqlPreparedStatement.() -> Unit)?
-    ): QueryResult<R> {
+    ): QueryResult<R> = QueryResult.AsyncValue {
+        var statement: Sqlite3.Statement? = null
         val cursor = SQLite3Cursor {
-            val statement = createOrGetStatement(identifier, sql)
-            statement.bind(parameters, binders)
-            statement
+            createOrGetStatement(identifier, sql).also {
+                statement = it
+                it.bind(parameters, binders)
+            }
         }
-        return mapper(cursor)
+        try {
+            mapper(cursor).await()
+        } finally {
+            statement?.finalizeUnlessCached()
+        }
     }
 
     override fun newTransaction(): QueryResult<Transacter.Transaction> = QueryResult.AsyncValue {

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Driver.kt
@@ -76,7 +76,10 @@ class SQLite3Driver internal constructor(private val db: Sqlite3.Database) : Sql
         return preparedStatement
     }
 
-    /** Statements cached by a transaction are reused and finalized by [Transaction.endTransaction], not by the caller. */
+    /**
+     * Statements cached by a transaction are reused and finalized by [Transaction.endTransaction],
+     * not by the caller.
+     */
     private suspend fun Sqlite3.Statement.finalizeUnlessCached() {
         if (transaction?.statements?.containsValue(this) != true) finalizeSuspending()
     }

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Exception.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3Exception.kt
@@ -10,7 +10,7 @@ open class SQLite3Exception(message: String) : Exception(message)
 /**
  * Exception that occurs from within SQLite 3 Node.js module.
  */
-class SQLite3JsException(private val err: Throwable?) : SQLite3Exception(err.nullable?.message ?: "unknown error") {
+class SQLite3JsException(private val err: Throwable?) : SQLite3Exception(err?.message ?: "unknown error") {
     /**
      * SQLite error number
      */

--- a/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/utils.kt
+++ b/src/jsMain/kotlin/cz/sazel/sqldelight/node/sqlite3/utils.kt
@@ -2,10 +2,8 @@ package cz.sazel.sqldelight.node.sqlite3
 
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.db.QueryResult
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 
 /**
@@ -13,36 +11,24 @@ import kotlinx.coroutines.flow.toList
  * Use this instead of non-async method [Query.executeAsList].
  * @return The result set of the underlying SQL statement as a list of RowType.
  */
-@Deprecated("Use awaitAsList() instead", ReplaceWith("awaitAsList()"))
+@Deprecated(
+    "Use awaitAsList() instead, will be removed in 0.7",
+    ReplaceWith("awaitAsList()", "app.cash.sqldelight.async.coroutines.awaitAsList")
+)
 suspend fun <T : Any> Query<T>.executeSuspendingAsList(): List<T> =
-    executeAsFlow().toList(mutableListOf())
+    executeAsFlow().toList()
 
 /**
  * Workaround suspending method to use with SQLite3 async driver.
  * Use this instead of non-async method [Query.executeAsList].
  * @return The result set of the underlying SQL statement as a list of RowType.
  */
-suspend fun <T : Any> Query<T>.executeAsFlow(): Flow<T> =
-    coroutineScope {
-        execute<Flow<T>> { cursor ->
-            return@execute QueryResult.Value(callbackFlow {
-                do {
-                    val hasNext = cursor.next().await()
-                    if (!hasNext) {
-                        close()
-                    } else {
-                        val row = mapper(cursor)
-                        send(row)
-                    }
-                } while (hasNext)
-                awaitClose()
-            })
-        }.await()
-    }
-
-internal val <T> T?.nullable: T?
-    get() = when (this) {
-        null -> null
-        undefined -> null
-        else -> this
-    }
+suspend fun <T : Any> Query<T>.executeAsFlow(): Flow<T> = flow {
+    execute { cursor ->
+        QueryResult.AsyncValue {
+            while (cursor.next().await()) {
+                emit(mapper(cursor))
+            }
+        }
+    }.await()
+}

--- a/src/jsMain/kotlin/node/sqlite3/sqlite3.module_sqlite3.kt
+++ b/src/jsMain/kotlin/node/sqlite3/sqlite3.module_sqlite3.kt
@@ -136,7 +136,7 @@ external object Sqlite3 {
         //open fun run(params: Any, callback: (self: RunResult, err: Error?) -> Unit = definedExternally): Statement /* this */
         open fun run(params: Any, callback: (self: Any?) -> Unit): Statement
         open fun run(params: Any): Statement /* this */
-        open fun get(callback: (row: Any?, row2: Any) -> Unit = definedExternally): Statement /* this */
+        open fun get(callback: (err: Error?, row: Any?) -> Unit = definedExternally): Statement /* this */
         open fun get(): Statement /* this */
         open fun get(
             params: Any,

--- a/src/jsMain/kotlin/node/sqlite3/sqlite3.module_sqlite3.kt
+++ b/src/jsMain/kotlin/node/sqlite3/sqlite3.module_sqlite3.kt
@@ -123,7 +123,7 @@ external object Sqlite3 {
     }
 
     internal open class Statement : node.events.EventEmitter {
-        open fun bind(params: Array<Any?>, callback: (self: Any?) -> Unit = definedExternally): Statement /* this */
+        open fun bind(params: Array<Any?>, callback: (err: Error?) -> Unit = definedExternally): Statement /* this */
 
         //        open fun bind(callback: (err: Error?) -> Unit = definedExternally): Statement /* this */
 //        open fun bind(): Statement /* this */
@@ -241,10 +241,10 @@ external object Sqlite3 {
             callback: (self: Statement, err: Error?, row: Any) -> Unit = definedExternally
         ): Database /* this */
 
-        open fun exec(sql: String, callback: (self: Any?) -> Unit = definedExternally): Database /* this */
+        open fun exec(sql: String, callback: (err: Error?) -> Unit = definedExternally): Database /* this */
 
         //open fun prepare(sql: String, callback: (self: Statement, err: Error?) -> Unit = definedExternally): Statement
-        open fun prepare(sql: String, callback: (self: Any) -> Unit): Statement
+        open fun prepare(sql: String, callback: (err: Error?) -> Unit): Statement
 
         open fun prepare(sql: String): Statement
         open fun prepare(sql: String, params: Any?, callback: (self: Any) -> Unit): Statement

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
@@ -29,6 +29,7 @@ class DriverWithLibraryTest {
             playerQueries = database.testDataBaseDontUseQueries
             database.fn()
         } finally {
+            driver.close()
             js("require('fs').unlinkSync(dbName)")
         }
     }

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 typealias Database = cz.sazel.sqldelight._dont_use.TestDatabaseDontUse
 
@@ -65,6 +67,34 @@ class DriverWithLibraryTest {
                 assertContains(it, initialPlayer)
                 assertEquals(1, it.size)
             }
+        }
+    }
+
+    /**
+     * Regression: [SQLite3Driver.Transaction.endTransaction] used to restore itself instead of the enclosing
+     * transaction, so every transaction after the first one skipped both BEGIN and ROLLBACK and silently committed.
+     */
+    @Test
+    fun testSecondTransactionStillBeginsAndRollsBack() = withDatabase {
+        transaction {
+            playerQueries.insertFullPlayerObject(HockeyPlayer(player_number = 8, full_name = "Teemu Selanne"))
+        }
+        assertNull(driver.currentTransaction())
+
+        val rolledBackPlayer = HockeyPlayer(player_number = 18, full_name = "Saku Koivu")
+        try {
+            transaction {
+                playerQueries.insertFullPlayerObject(rolledBackPlayer)
+                error("Rollback")
+            }
+        } catch (e: Exception) {
+            // do nothing
+        }
+
+        playerQueries.selectAll().awaitAsList().let {
+            assertFalse(rolledBackPlayer in it)
+            assertContains(it, initialPlayer)
+            assertEquals(2, it.size)
         }
     }
 

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/DriverWithLibraryTest.kt
@@ -3,6 +3,8 @@ package cz.sazel.sqldelight.node.sqlite3
 import app.cash.sqldelight.async.coroutines.awaitAsList
 import cz.sazel.sqldelight.dontuse.HockeyPlayer
 import cz.sazel.sqldelight.dontuse.TestDataBaseDontUseQueries
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -133,6 +135,38 @@ class DriverWithLibraryTest {
         playerQueries.selectAll().awaitAsList().let {
             assertEquals(0, it.size)
         }
+    }
+
+    @Test
+    fun testExecuteAsFlowReturnsAllRows() = withDatabase {
+        val insertedPlayers = (0..4).map { HockeyPlayer(player_number = 200L + it, full_name = "Flow $it") }
+        transaction {
+            insertedPlayers.forEach { playerQueries.insertFullPlayerObject(it) }
+        }
+        playerQueries.selectAll().executeAsFlow().toList().let {
+            assertContains(it, initialPlayer)
+            assertEquals(6, it.size)
+        }
+    }
+
+    /**
+     * Regression: the cursor used to be created eagerly and captured by the returned flow, so collecting it a
+     * second time reused an already exhausted cursor and yielded nothing.
+     */
+    @Test
+    fun testExecuteAsFlowIsColdAndCanBeCollectedTwice() = withDatabase {
+        val flow = playerQueries.selectAll().executeAsFlow()
+        assertEquals(listOf(initialPlayer), flow.toList())
+        assertEquals(listOf(initialPlayer), flow.toList())
+    }
+
+    @Test
+    fun testExecuteAsFlowSupportsPartialCollection() = withDatabase {
+        val insertedPlayers = (0..9).map { HockeyPlayer(player_number = 300L + it, full_name = "Partial $it") }
+        transaction {
+            insertedPlayers.forEach { playerQueries.insertFullPlayerObject(it) }
+        }
+        assertEquals(3, playerQueries.selectAll().executeAsFlow().take(3).toList().size)
     }
 
     @Test

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
@@ -127,6 +127,24 @@ class SQLite3DriverTest {
         }
     }
 
+    /**
+     * Regression: [SQLite3Driver.execute] used to discard the statement's `changes` and always return 0.
+     */
+    @Test
+    fun execute_returns_number_of_rows_affected() = runTest { driver ->
+        assertEquals(1, driver.execute(20, "INSERT INTO test VALUES (?, ?);", 2) {
+            bindLong(0, 1)
+            bindString(1, "Alec")
+        }.await())
+        assertEquals(1, driver.execute(21, "INSERT INTO test VALUES (?, ?);", 2) {
+            bindLong(0, 2)
+            bindString(1, "Jake")
+        }.await())
+        assertEquals(2, driver.execute(22, "UPDATE test SET value = 'Whoever'", 0).await())
+        assertEquals(1, driver.execute(23, "DELETE FROM test WHERE id = ?", 1) { bindLong(0, 1) }.await())
+        assertEquals(1, driver.execute(24, "DELETE FROM test", 0).await())
+    }
+
     @Test
     fun query_can_run_multiple_times() = runTest { driver ->
 

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
@@ -273,7 +273,7 @@ class SQLite3DriverTest {
         try {
             assertTrue(success)
         } finally {
-            (driver as SQLite3Driver)._endTransactionForTests(success)
+            (driver as SQLite3Driver)._endTransactionForTests(success)?.await()
         }
     }
 
@@ -296,7 +296,7 @@ class SQLite3DriverTest {
         try {
             assertFalse(success)
         } finally {
-            (driver as SQLite3Driver)._endTransactionForTests(success)
+            (driver as SQLite3Driver)._endTransactionForTests(success)?.await()
         }
     }
 

--- a/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
+++ b/src/jsTest/kotlin/cz/sazel/sqldelight/node/sqlite3/SQLite3DriverTest.kt
@@ -204,7 +204,7 @@ class SQLite3DriverTest {
             return driver.awaitQuery(4, "SELECT changes()", mapper, 0)
         }
 
-        val inserted = insert {
+        insert {
             bindLong(0, 1)
             bindLong(1, null)
             bindString(2, null)

--- a/src/jsTest/kotlin/node/sqlite3/BasicSQLOperationsTest.kt
+++ b/src/jsTest/kotlin/node/sqlite3/BasicSQLOperationsTest.kt
@@ -14,10 +14,9 @@ class BasicSQLOperationsTest {
     @Test
     fun testCreateDb() = runTest {
 
-        val x = Sqlite3
         val db: Sqlite3.Database =
             Sqlite3.Database("test.db", mode = Sqlite3.OPEN_CREATE.toInt() or Sqlite3.OPEN_READWRITE.toInt())
-        val res = suspendCoroutine { cont ->
+        suspendCoroutine { cont ->
             db.run(
                 """CREATE TABLE contacts (
                 contact_id INTEGER PRIMARY KEY,
@@ -29,7 +28,7 @@ class BasicSQLOperationsTest {
                 it?.let { cont.resumeWithException(it as Throwable) } ?: cont.resume(it)
             }
         }
-        val statement = suspendCoroutine { cont ->
+        suspendCoroutine { cont ->
             db.run(
                 "INSERT INTO contacts (contact_id,first_name,last_name,email,phone) " +
                         "VALUES (?,?,?,?,?)", js("[1, \"Petr\", \"Novak\", \"petr.novak@gmail.com\", \"1234\"]")
@@ -37,7 +36,7 @@ class BasicSQLOperationsTest {
                 it?.let { cont.resumeWithException(it as Throwable) } ?: cont.resume(it)
             }
         }
-        val statement2 = suspendCoroutine { cont ->
+        suspendCoroutine { cont ->
             db.run(
                 "INSERT INTO contacts (contact_id,first_name,last_name,email,phone) " +
                         "VALUES (?,?,?,?,?)",


### PR DESCRIPTION
## Motivation

Started as a cleanup of `suspendCoroutine` cancellation warnings. Auditing call sites turned up real correctness bugs, most seriously: every transaction after first silently committed instead of rolling back.

## Notes

Each fix ships with a test that fails against the old code:

- Nested transactions never closed out: `endTransaction` restored itself instead of enclosing transaction, so second and later `transaction { }` blocks skipped both `BEGIN` and `ROLLBACK` and silently committed.
- Statement leak: `executeQuery` had no cleanup path. It now owns statement lifetime via `try/finally`, with check so transaction-cached statements stay owned by `endTransaction`. Removes `SQLITE_BUSY` warnings on close.
- `execute` always returned 0 instead of rows affected.
- `executeAsFlow` was not cold: cursor was created eagerly and captured, so second collection yielded nothing. Now a plain `flow { }`; old `callbackFlow` registered no callbacks.
- Wrong externals: `get`/`exec`/`prepare`/`bind` callbacks had `err` misnamed `self` and typed non-null. Corrected against `sqlite3.d.ts`. `reset` deliberately left as `Nothing?`; upstream really does always pass null.
- Cleanups: `suspendCancellableCoroutine` throughout, dead cursor state removed, `nullable` helper dropped (it was an identity function).

Commits are ordered so each one builds and passes on its own.

### Heads-up

- `execute` returning real counts is a user-visible change from old constant `0`.
- Statement lifetime now ends when mapper's `QueryResult` completes. SQLDelight accessors consume cursor inside mapper and are unaffected, but a custom mapper holding cursor past that point would break.
